### PR TITLE
Aggiunge README per servizio utenti

### DIFF
--- a/Desktop/A_Tuo_Servizio/services/servizio_utenti/README.md
+++ b/Desktop/A_Tuo_Servizio/services/servizio_utenti/README.md
@@ -1,0 +1,40 @@
+# Servizio Utenti
+
+Questo microservizio gestisce la registrazione, l'autenticazione e la gestione degli utenti della piattaforma.
+
+## Dipendenze principali
+- Python 3.9+
+- FastAPI
+- SQLAlchemy
+- Pydantic
+- passlib[bcrypt]
+- python-jose
+- pytest (per i test)
+
+I pacchetti necessari sono elencati in `docs/feat-user-service-v1/requirements.txt`.
+
+## Avvio locale
+1. Creare e attivare un ambiente virtuale:
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r ../../docs/feat-user-service-v1/requirements.txt
+    ```
+2. Avviare il servizio con Uvicorn:
+    ```bash
+    uvicorn app.main:app --reload
+    ```
+
+## Variabili d'ambiente esempio
+```
+SECRET_KEY=supersecret
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+```
+Le variabili possono essere definite in un file `.env` oppure esportate nel proprio ambiente.
+
+## Test
+I test automatici si trovano nella cartella `tests/` e sono basati su **pytest**.
+Per eseguirli:
+```bash
+pytest tests
+```


### PR DESCRIPTION
## Summary
- aggiunto `services/servizio_utenti/README.md` con guida su finalità, dipendenze e avvio

## Testing
- `pytest -q Desktop/A_Tuo_Servizio/services/servizio_utenti/tests` *(fallisce: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68433fb02a54832b886ebd0a8e72bc8b