### PR TITLE
Add docker-compose setup

### DIFF
--- a/Desktop/A_Tuo_Servizio/README.md
+++ b/Desktop/A_Tuo_Servizio/README.md
@@ -28,10 +28,16 @@ Progetto modulare per una piattaforma di servizi professionali, organizzata in m
 
 ## Guida rapida
 
-1. Crea l’ambiente virtuale e installa dipendenze (per Django e microservizi FastAPI/NodeJS).  
-2. Avvia i container Docker definiti nei `Dockerfile` di ogni microservizio sotto `services/`.  
-3. Consulta la documentazione in `docs/` per istruzioni dettagliate su mockup, API e flussi dati.  
-4. Esegui gli script di manutenzione presenti in `scripts/`.  
+1. Crea l’ambiente virtuale e installa dipendenze (per Django e microservizi FastAPI/NodeJS).
+2. Avvia l’intera piattaforma tramite `docker-compose` posizionandoti nella root del progetto e lanciando:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+   Il comando avvia tutti i microservizi e i relativi database.
+3. Consulta la documentazione in `docs/` per istruzioni dettagliate su mockup, API e flussi dati.
+4. Esegui gli script di manutenzione presenti in `scripts/`.
 
 ## Scelte architetturali
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,134 @@
+version: "3.9"
+services:
+  servizio_utenti:
+    build: ./Desktop/A_Tuo_Servizio/services/servizio_utenti
+    ports:
+      - "8000:8000"
+
+  servizio_profili_professionisti:
+    build: ./Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti
+    ports:
+      - "8001:8000"
+
+  servizio_portfolio:
+    build: ./Desktop/A_Tuo_Servizio/services/servizio_portfolio
+    ports:
+      - "8002:8000"
+
+  servizio_ricerca:
+    build: ./Desktop/A_Tuo_Servizio/services/servizio_ricerca
+    ports:
+      - "8003:8000"
+
+  calendar-svc:
+    image: node:20
+    working_dir: /usr/src/app
+    volumes:
+      - ./Desktop/A_Tuo_Servizio/services/calendar-svc:/usr/src/app
+    command: sh -c "npm install && node index.js"
+    environment:
+      - PORT=3002
+      - DB_HOST=calendar-db
+      - DB_USER=calendar_user
+      - DB_PASSWORD=password
+      - DB_NAME=calendar_db
+      - DB_PORT=5432
+    ports:
+      - "3002:3002"
+    depends_on:
+      - calendar-db
+
+  chat-svc:
+    image: node:20
+    working_dir: /usr/src/app
+    volumes:
+      - ./Desktop/A_Tuo_Servizio/services/chat-svc:/usr/src/app
+    command: sh -c "npm install && node index.js"
+    environment:
+      - PORT=3001
+      - MONGO_URI=mongodb://mongo:27017/chat_db
+      - KAFKA_BROKERS=kafka:9092
+    ports:
+      - "3001:3001"
+    depends_on:
+      - mongo
+      - kafka
+
+  quote-svc:
+    image: node:20
+    working_dir: /usr/src/app
+    volumes:
+      - ./Desktop/A_Tuo_Servizio/services/quote-svc:/usr/src/app
+    command: sh -c "npm install && node index.js"
+    environment:
+      - PORT=3000
+      - DB_HOST=quotes-db
+      - DB_USER=user
+      - DB_PASSWORD=password
+      - DB_NAME=quotes_db
+      - DB_PORT=5432
+      - KAFKA_BROKERS=kafka:9092
+    ports:
+      - "3000:3000"
+    depends_on:
+      - quotes-db
+      - kafka
+
+  calendar-db:
+    image: postgres:13
+    restart: always
+    environment:
+      POSTGRES_USER: calendar_user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: calendar_db
+    ports:
+      - "5433:5432"
+    volumes:
+      - calendar_db_data:/var/lib/postgresql/data
+
+  quotes-db:
+    image: postgres:13
+    restart: always
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: quotes_db
+    ports:
+      - "5434:5432"
+    volumes:
+      - quotes_db_data:/var/lib/postgresql/data
+
+  mongo:
+    image: mongo:6
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    restart: always
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: bitnami/kafka:latest
+    restart: always
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://0.0.0.0:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+
+volumes:
+  calendar_db_data:
+  quotes_db_data:
+  mongo_data:


### PR DESCRIPTION
## Summary
- add root docker-compose.yml to orchestrate services and databases
- document docker-compose usage in main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68433fb15f98832b80c806e6b7d210ba