### PR TITLE
Improve service configs

### DIFF
--- a/Desktop/A_Tuo_Servizio/front-end/.env.example
+++ b/Desktop/A_Tuo_Servizio/front-end/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/Desktop/A_Tuo_Servizio/front-end/README.md
+++ b/Desktop/A_Tuo_Servizio/front-end/README.md
@@ -13,6 +13,7 @@ This project is the frontend application for `client-autoservizio`.
 1. Clone the repository.
 2. Navigate to the `client-autoservizio` directory: `cd client-autoservizio`
 3. Install dependencies: `npm install` (or `yarn install`)
+4. Copy `.env.example` to `.env` and adjust `VITE_API_BASE_URL` if your backend runs on a different URL.
 
 ### Running the Development Server
 ```bash

--- a/Desktop/A_Tuo_Servizio/front-end/src/servizi/apiClient.ts
+++ b/Desktop/A_Tuo_Servizio/front-end/src/servizi/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: 'http://localhost:8000', // TODO: Configurare l'URL base corretto per le API backend
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
   // headers: {
   //   'Content-Type': 'application/json',
   // },

--- a/Desktop/A_Tuo_Servizio/services/calendar-svc/README.md
+++ b/Desktop/A_Tuo_Servizio/services/calendar-svc/README.md
@@ -59,6 +59,8 @@ A unique constraint exists on `(professional_id, start_time)`.
     npm install
     ```
 
+3.  Copy `.env.example` to `.env` and modify database parameters if needed.
+
 ## Running the Service
 
 1.  Ensure your PostgreSQL database is running and accessible with the configured credentials.

--- a/Desktop/A_Tuo_Servizio/services/chat-svc/README.md
+++ b/Desktop/A_Tuo_Servizio/services/chat-svc/README.md
@@ -50,7 +50,8 @@ Configure these environment variables before running the service. For developmen
     npm install
     ```
 
-3.  Ensure the `uploads` directory exists within `chat-svc` if not created automatically by the service start-up.
+3.  Copy `.env.example` to `.env` and adjust values like `MONGO_URI` or `KAFKA_BROKERS` if needed.
+4.  Ensure the `uploads` directory exists within `chat-svc` if not created automatically by the service start-up.
 
 ## Running the Service
 

--- a/Desktop/A_Tuo_Servizio/services/quote-svc/README.md
+++ b/Desktop/A_Tuo_Servizio/services/quote-svc/README.md
@@ -43,6 +43,8 @@ Before running the service, you would typically set up the following environment
     npm install
     ```
 
+3.  Copy `.env.example` to `.env` and adjust the database or Kafka settings if needed.
+
 ## Running the Service
 
 1.  Ensure your PostgreSQL database and Kafka cluster are running and accessible with the configured credentials/addresses.

--- a/Desktop/A_Tuo_Servizio/services/servizio_portfolio/.env.example
+++ b/Desktop/A_Tuo_Servizio/services/servizio_portfolio/.env.example
@@ -1,1 +1,2 @@
 SECRET_KEY=change_me
+DATABASE_URL=sqlite:///./portfolio.db

--- a/Desktop/A_Tuo_Servizio/services/servizio_portfolio/README.md
+++ b/Desktop/A_Tuo_Servizio/services/servizio_portfolio/README.md
@@ -1,3 +1,12 @@
 # Servizio Portfolio
 
 Questo servizio è responsabile della gestione dei portfolio dei professionisti, includendo progetti, descrizioni, media associati (immagini, video), e tecnologie utilizzate.
+
+## Avvio rapido
+
+1. Crea un ambiente virtuale ed installa le dipendenze indicate in `requirements.txt`.
+2. Copia `.env.example` in `.env` e personalizza `SECRET_KEY` e `DATABASE_URL` se necessario.
+3. Avvia il server con:
+   ```bash
+   uvicorn app.main:app --reload
+   ```

--- a/Desktop/A_Tuo_Servizio/services/servizio_portfolio/app/core/config.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_portfolio/app/core/config.py
@@ -6,7 +6,8 @@ class Settings(BaseSettings):
     # e Servizio Profili per una corretta validazione del token.
     SECRET_KEY: str = os.getenv("SECRET_KEY", "a_very_secret_key_that_should_be_changed_in_production_and_loaded_from_env")
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30 # Anche se questo servizio valida, è bene averlo per coerenza
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # Anche se questo servizio valida, è bene averlo per coerenza
+    DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./portfolio.db")
 
     # Eventuali altre configurazioni specifiche per il servizio portfolio
     # Esempio: MAX_PROJECTS_PER_USER: int = 10

--- a/Desktop/A_Tuo_Servizio/services/servizio_portfolio/app/db/database.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_portfolio/app/db/database.py
@@ -2,12 +2,15 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.ext.declarative import declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./portfolio.db" # Database specifico per i portfolio
+from ..core.config import settings
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, 
-    connect_args={"check_same_thread": False} # Necessario solo per SQLite
-)
+SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL  # Database specifico per i portfolio
+
+engine_args = {}
+if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+    engine_args["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, **engine_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/.env.example
+++ b/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/.env.example
@@ -1,1 +1,2 @@
 SECRET_KEY=change_me
+DATABASE_URL=sqlite:///./profiles.db

--- a/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/README.md
+++ b/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/README.md
@@ -1,3 +1,12 @@
 # Servizio Profili Professionisti
 
 Questo servizio è responsabile della gestione dei profili dei professionisti, includendo le loro competenze, aree di specializzazione, certificazioni e disponibilità.
+
+## Avvio rapido
+
+1. Crea un ambiente virtuale ed installa le dipendenze indicate in `requirements.txt`.
+2. Copia `.env.example` in `.env` e personalizza `SECRET_KEY` e `DATABASE_URL` se necessario.
+3. Avvia il server con:
+   ```bash
+   uvicorn app.main:app --reload
+   ```

--- a/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/app/core/config.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/app/core/config.py
@@ -6,11 +6,10 @@ class Settings(BaseSettings):
     # per una corretta validazione del token.
     SECRET_KEY: str = os.getenv("SECRET_KEY", "a_very_secret_key_that_should_be_changed_in_production_and_loaded_from_env")
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30 # Questo valore è più per l'emissione, ma per coerenza
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # Questo valore è più per l'emissione, ma per coerenza
+    DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./profiles.db")
 
     # Eventuali altre configurazioni specifiche per il servizio profili
-    # Esempio: DATABASE_URL: str = "sqlite:///./profiles.db" 
-    # (anche se di solito la URL del DB è in database.py o caricata diversamente)
 
     class Config:
         env_file = ".env"

--- a/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/app/db/database.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_profili_professionisti/app/db/database.py
@@ -2,12 +2,15 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.ext.declarative import declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./profiles.db" # Database specifico per i profili
+from ..core.config import settings
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, 
-    connect_args={"check_same_thread": False} # Necessario solo per SQLite
-)
+SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL  # Database specifico per i profili
+
+engine_args = {}
+if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+    engine_args["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, **engine_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/Desktop/A_Tuo_Servizio/services/servizio_ricerca/README.md
+++ b/Desktop/A_Tuo_Servizio/services/servizio_ricerca/README.md
@@ -1,3 +1,12 @@
 # Servizio Ricerca
 
 Questo servizio è responsabile di fornire funzionalità di ricerca avanzata sui dati dei professionisti e dei loro portfolio, interagendo con un motore di ricerca come OpenSearch o Elasticsearch.
+
+## Avvio rapido
+
+1. Crea un ambiente virtuale ed installa le dipendenze elencate in `requirements.txt`.
+2. Copia `.env.example` in `.env` e personalizza `OPENSEARCH_URL` e `PROFILI_INDEX_NAME` se necessario.
+3. Avvia il servizio con:
+   ```bash
+   uvicorn app.main:app --reload
+   ```

--- a/Desktop/A_Tuo_Servizio/services/servizio_utenti/.env.example
+++ b/Desktop/A_Tuo_Servizio/services/servizio_utenti/.env.example
@@ -1,1 +1,2 @@
 SECRET_KEY=change_me
+DATABASE_URL=sqlite:///./app.db

--- a/Desktop/A_Tuo_Servizio/services/servizio_utenti/README.md
+++ b/Desktop/A_Tuo_Servizio/services/servizio_utenti/README.md
@@ -17,7 +17,7 @@ Questo microservizio espone API per la registrazione, il login e la gestione dei
    ```bash
    pip install -r requirements.txt
    ```
-3. Copiare `.env.example` in `.env` e personalizzare il `SECRET_KEY`:
+3. Copiare `.env.example` in `.env` e personalizzare le variabili `SECRET_KEY` e `DATABASE_URL` se necessario:
    ```bash
    cp .env.example .env
    ```

--- a/Desktop/A_Tuo_Servizio/services/servizio_utenti/app/core/config.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_utenti/app/core/config.py
@@ -2,9 +2,13 @@ from pydantic import BaseSettings
 import os
 
 class Settings(BaseSettings):
-    SECRET_KEY: str = os.getenv("SECRET_KEY", "a_very_secret_key_that_should_be_changed_in_production_and_loaded_from_env")
+    SECRET_KEY: str = os.getenv(
+        "SECRET_KEY",
+        "a_very_secret_key_that_should_be_changed_in_production_and_loaded_from_env",
+    )
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
     class Config:
         env_file = ".env" 

--- a/Desktop/A_Tuo_Servizio/services/servizio_utenti/app/db/database.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_utenti/app/db/database.py
@@ -2,12 +2,15 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.ext.declarative import declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
-# SQLALCHEMY_DATABASE_URL = "postgresql://user:password@postgresserver/db"
+from ..core.config import settings
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False} # Needed only for SQLite
-)
+SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL
+
+engine_args = {}
+if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+    engine_args["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, **engine_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/Desktop/A_Tuo_Servizio/services/servizio_utenti/app/db/models/utente.py
+++ b/Desktop/A_Tuo_Servizio/services/servizio_utenti/app/db/models/utente.py
@@ -1,7 +1,5 @@
 from sqlalchemy import Column, Integer, String, DateTime, func
-from sqlalchemy.ext.declarative import declarative_base
-
-Base = declarative_base()
+from ..database import Base
 
 class Utente(Base):
     __tablename__ = "utenti"


### PR DESCRIPTION
## Summary
- load `DATABASE_URL` in settings for Python services
- document environment variables in service READMEs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6843e190c270832b9bb117633fa29d7f